### PR TITLE
Do not register application tracer

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ In your application start:
 
 ```elixir
     def start(_type, _args) do
-      OpenTelemetry.register_application_tracer(:my_project)
       OpentelemetryLoggerMetadata.setup()
 
       # ...


### PR DESCRIPTION
There is no need to register the application tracer.

OpenTelemetry automatically registers the application tracer. They removed the function on the version `1.0.0.0-rc.3`. [Here](https://github.com/open-telemetry/opentelemetry-erlang/blob/0ec0e863215466dbdec153b99b2873e1e695ce22/CHANGELOG.md?plain=1#L468) is the changelog.